### PR TITLE
fix: added pipefail

### DIFF
--- a/.github/workflows/build-validation.yaml
+++ b/.github/workflows/build-validation.yaml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -30,12 +30,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for the container
         id: meta
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 #v5.6.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push container image
-        uses: docker/build-push-action@v6.9.0
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 #v6.13.0
         with:
           context: .
           push: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 # 01. Terraform
 echo "Installing Terraform..."
-curl -f -m 0.1 https://releases.hashicorp.com/terraform/1.12.0/terraform_1.12.0_linux_amd64.zip -o terraform.zip
+curl -m 0.1 https://releases.hashicorp.com/terraform/1.12.0/terraform_1.12.0_linux_amd64.zip -o terraform.zip
 unzip terraform.zip
 sudo mv terraform /usr/local/bin/terraform
 rm terraform.zip

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # This script is used to install the tools required for the platform.
 
+# Fail script on any error
+set -euo pipefail
+
 # 01. Terraform
 echo "Installing Terraform..."
 curl https://releases.hashicorp.com/terraform/1.12.0/terraform_1.12.0_linux_amd64.zip -o terraform.zip && unzip terraform.zip && sudo mv terraform /usr/local/bin/terraform && rm terraform.zip

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 # 01. Terraform
 echo "Installing Terraform..."
-curl -m 0.1 https://releases.hashicorp.com/terraform/1.12.0/terraform_1.12.0_linux_amd64.zip -o terraform.zip && unzip terraform.zip && sudo mv terraform /usr/local/bin/terraform && rm terraform.zip
+curl -f -m 0.1 https://releases.hashicorp.com/terraform/1.12.0/terraform_1.12.0_linux_amd64.zip -o terraform.zip && unzip terraform.zip && sudo mv terraform /usr/local/bin/terraform && rm terraform.zip
 echo "Terraform installed successfully."
 
 # 02. Azure CLI

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 # 01. Terraform
 echo "Installing Terraform..."
-curl https://releases.hashicorp.com/terraform/1.12.0/terraform_1.12.0_linux_amd64.zip -o terraform.zip && unzip terraform.zip && sudo mv terraform /usr/local/bin/terraform && rm terraform.zip
+curl -m 0.1 https://releases.hashicorp.com/terraform/1.12.0/terraform_1.12.0_linux_amd64.zip -o terraform.zip && unzip terraform.zip && sudo mv terraform /usr/local/bin/terraform && rm terraform.zip
 echo "Terraform installed successfully."
 
 # 02. Azure CLI

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 # 01. Terraform
 echo "Installing Terraform..."
-curl -m 0.1 https://releases.hashicorp.com/terraform/1.12.0/terraform_1.12.0_linux_amd64.zip -o terraform.zip
+curl https://releases.hashicorp.com/terraform/1.12.0/terraform_1.12.0_linux_amd64.zip -o terraform.zip
 unzip terraform.zip
 sudo mv terraform /usr/local/bin/terraform
 rm terraform.zip

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 
 # 01. Terraform
 echo "Installing Terraform..."
-curl -f -m 0.1 https://releases.hashicorp.com/terraform/1.12.0/terraform_1.12.0_linux_amd64.zip -o terraform.zip && unzip terraform.zip && sudo mv terraform /usr/local/bin/terraform && rm terraform.zip
+curl -f -m 0.1 https://releases.hashicorp.com/terraform/1.12.0/terraform_1.12.0_linux_amd64.zip -o terraform.zip
+unzip terraform.zip
+sudo mv terraform /usr/local/bin/terraform
+rm terraform.zip
 echo "Terraform installed successfully."
 
 # 02. Azure CLI
@@ -52,17 +55,20 @@ curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/v0.279.0/insta
 echo "Installing Bruno..."
 curl -sfL https://github.com/usebruno/bruno/releases/download/v2.3.0/bruno_2.3.0_amd64_linux.deb -o bruno.deb
 sudo apt install libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 xdg-utils libatspi2.0-0 libsecret-1-0 -y
-sudo dpkg -i bruno.deb && rm bruno.deb && echo "Bruno installed successfully."
+sudo dpkg -i bruno.deb
+rm bruno.deb
+echo "Bruno installed successfully."
 
 # 05. gh cli
 echo "Installing gh cli..."
-(type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
-	&& sudo mkdir -p -m 755 /etc/apt/keyrings \
-	&& wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-	&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-	&& sudo apt update \
-	&& sudo apt install gh -y && echo "gh cli installed successfully."
+type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)
+sudo mkdir -p -m 755 /etc/apt/keyrings
+wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+sudo apt update
+sudo apt install gh -y
+echo "gh cli installed successfully."
 
 # 06. ORAS
 echo "Installing oras..."


### PR DESCRIPTION
Adding pipefail to stop docker build in case of an error during installation of tools.

Also unchained "&&" blocks to make pipefail work for those installs as well.

Fabricated timeout can be seen in this run: https://github.com/Bane-NOR/actions-runner/actions/runs/24070074430/job/70204707229

Where the workflow fails.

Also updated github actions to use latest versions, with sha pinning